### PR TITLE
Check fixups

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,1 @@
+COAT\.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,15 +5,14 @@ Version: 0.1.0
 Date: 2023-02-23
 Authors@R: c(person("Alexander", "Hapfelmeier", role = c("aut", "cre"),
                       email = "Alexander.Hapfelmeier@mri.tum.de"),
-             person("Siranush", "Karapetyan", role = c("aut"), 
+             person("Siranush", "Karapetyan", role = "aut", 
                       email = "Siranush.Karapetyan@mri.tum.de"))
 Description: Agreement of continuously scaled measurements made by two techniques, devices or methods is usually evaluated by the well-established Bland-Altman analysis or plot. COAT embeds the latter in the framework of recursive partitioning to explore heterogeneous method agreement in dependence of covariates. COAT can also be used to perform a two-sample Bland-Altman test for differences in method agreement.
 License: GPL-3
 Depends: R (>= 3.5.0)
-Imports: partykit, MethComp, ggplot2, strucchange, grid, ggparty, gridExtra
-Suggests: disttree
+Imports: partykit, ggplot2, strucchange, grid, ggparty, gridExtra
+Suggests: disttree, MethComp
 Additional_repositories: http://R-Forge.R-project.org
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
-
+RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,4 @@
 Package: COAT
-Type: Package
 Title: Conditional Method Agreement Trees (COAT) and Forests
 Version: 0.1.0
 Date: 2023-02-23
@@ -12,7 +11,6 @@ License: GPL-3
 Depends: R (>= 3.5.0)
 Imports: partykit, ggplot2, strucchange, grid, ggparty, gridExtra
 Suggests: disttree, MethComp
-Additional_repositories: http://R-Forge.R-project.org
+Additional_repositories: https://R-Forge.R-project.org
 Encoding: UTF-8
-LazyData: true
 RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Conditional Method Agreement Trees (COAT) and Forests
 Version: 0.1.0
 Date: 2023-02-23
 Authors@R: c(person("Alexander", "Hapfelmeier", role = c("aut", "cre"),
-                      email = "Alexander.Hapfelmeier@mri.tum.de"),
+                      email = "Alexander.Hapfelmeier@mri.tum.de", comment = c(ORCID = "0000-0001-6765-6352")),
              person("Siranush", "Karapetyan", role = "aut", 
                       email = "Siranush.Karapetyan@mri.tum.de"))
 Description: Agreement of continuously scaled measurements made by two techniques, devices or methods is usually evaluated by the well-established Bland-Altman analysis or plot. COAT embeds the latter in the framework of recursive partitioning to explore heterogeneous method agreement in dependence of covariates. COAT can also be used to perform a two-sample Bland-Altman test for differences in method agreement.

--- a/R/BAtest.R
+++ b/R/BAtest.R
@@ -13,12 +13,16 @@
 #' @param ... further arguments passed to \code{\link[partykit]{ctree_control}}.
 #'
 #' @examples
+#' \dontshow{ if(!requireNamespace("MethComp")) {
+#'   if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+#'     stop("the MethComp package is required for this example but is not installed")
+#'   } else q() }
+#' }
 #' ### load package ###
 #' library("COAT")
 #'
 #' ### data ###
-#' require(MethComp)
-#' data(VitCap)
+#' data("VitCap", package = "MethComp")
 #' ## transform data to required 'wide' format
 #' VitCap_wide <- reshape(VitCap, v.names = "y", timevar = "instrument",
 #'                        idvar = c("item", "user"), drop = "meth", direction = "wide")

--- a/R/coarf.R
+++ b/R/coarf.R
@@ -12,12 +12,16 @@
 #' @details See \code{\link[disttree]{distforest}} for implementation details.
 #'
 #' @examples
+#' \dontshow{ if(!requireNamespace("MethComp")) {
+#'   if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+#'     stop("the MethComp package is required for this example but is not installed")
+#'   } else q() }
+#' }
 #' ### load package ###
 #' library("COAT")
 #'
 #' ### data ###
-#' require(MethComp)
-#' data(scint)
+#' data("scint", package = "MethComp")
 #' ## transform data to required 'wide' format
 #' scint_wide <- reshape(scint, v.names = "y", timevar = "meth", idvar = "item", direction = "wide")
 #'

--- a/R/coat.R
+++ b/R/coat.R
@@ -17,12 +17,16 @@
 #' @details The minimum number of observations required to model conditional agreement defaults to 20. Users may choose to modify this value as needed. See \code{\link[partykit]{ctree_control}} and \code{\link[partykit]{mob_control}} for details.
 #'
 #' @examples
+#' \dontshow{ if(!requireNamespace("MethComp")) {
+#'   if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+#'     stop("the MethComp package is required for this example but is not installed")
+#'   } else q() }
+#' }
 #' ### load package ###
 #' library("COAT")
 #'
 #' ### data ###
-#' require(MethComp)
-#' data(scint)
+#' data("scint", package = "MethComp")
 #' ## transform data to required 'wide' format
 #' scint_wide <- reshape(scint, v.names = "y", timevar = "meth", idvar = "item", direction = "wide")
 #'

--- a/man/BAtest.Rd
+++ b/man/BAtest.Rd
@@ -41,18 +41,22 @@ Function to perform a two-sample Bland-Altman test for hypothesis testing of dif
 }
 \section{Methods (by generic)}{
 \itemize{
-\item \code{print}: function to print the result of the Bland-Altman test.
+\item \code{print(BAtest)}: function to print the result of the Bland-Altman test.
 
-\item \code{plot}: function to plot the result of the Bland-Altman test.
+\item \code{plot(BAtest)}: function to plot the result of the Bland-Altman test.
+
 }}
-
 \examples{
+\dontshow{ if(!requireNamespace("MethComp")) {
+  if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+    stop("the MethComp package is required for this example but is not installed")
+  } else q() }
+}
 ### load package ###
 library("COAT")
 
 ### data ###
-require(MethComp)
-data(VitCap)
+data("VitCap", package = "MethComp")
 ## transform data to required 'wide' format
 VitCap_wide <- reshape(VitCap, v.names = "y", timevar = "instrument",
                        idvar = c("item", "user"), drop = "meth", direction = "wide")

--- a/man/coarf.Rd
+++ b/man/coarf.Rd
@@ -29,12 +29,16 @@ Function to model conditional method agreement by \code{\link[disttree]{distfore
 See \code{\link[disttree]{distforest}} for implementation details.
 }
 \examples{
+\dontshow{ if(!requireNamespace("MethComp")) {
+  if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+    stop("the MethComp package is required for this example but is not installed")
+  } else q() }
+}
 ### load package ###
 library("COAT")
 
 ### data ###
-require(MethComp)
-data(scint)
+data("scint", package = "MethComp")
 ## transform data to required 'wide' format
 scint_wide <- reshape(scint, v.names = "y", timevar = "meth", idvar = "item", direction = "wide")
 

--- a/man/coat.Rd
+++ b/man/coat.Rd
@@ -49,18 +49,22 @@ Functions to fit and plot COAT models.
 \details{
 The minimum number of observations required to model conditional agreement defaults to 20. Users may choose to modify this value as needed. See \code{\link[partykit]{ctree_control}} and \code{\link[partykit]{mob_control}} for details.
 }
-\section{Methods (by generic)}{
+\section{Functions}{
 \itemize{
-\item \code{plot}: function to plot a COAT model.
-}}
+\item \code{plot(COAT)}: function to plot a COAT model.
 
+}}
 \examples{
+\dontshow{ if(!requireNamespace("MethComp")) {
+  if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+    stop("the MethComp package is required for this example but is not installed")
+  } else q() }
+}
 ### load package ###
 library("COAT")
 
 ### data ###
-require(MethComp)
-data(scint)
+data("scint", package = "MethComp")
 ## transform data to required 'wide' format
 scint_wide <- reshape(scint, v.names = "y", timevar = "meth", idvar = "item", direction = "wide")
 


### PR DESCRIPTION
Alexander, I made a few fixups to help passing `R CMD check` for CRAN:

* The `MethComp` package was moved from `Depends` to `Suggests` because the R code of the package has nothing that it needs to import from the package. In the examples I added a couple of lines at the beginning (not shown to the user) that checks whether the package is available and throws an informative error otherwise. Finally, I don't actually attach the package because we only need the data from it so `data(..., package = "Methcomp")` is enough.
* I added an `.Rbuildignore` file to make sure that `COAT.Rproj` is not included in the source package.
* I omitted a couple of unnecessary fields from the `DESCRIPTION`.
* I added your ORCID but not the one of Siranush because I wasn't sure if/which of those listed on ORCID is hers.