### PR TITLE
allow specification of measurement pair via y1 - y2 ~ ...

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,17 @@
+# Version 0.2.0
+
+* First CRAN release of the package, accompanying the publication of a working
+  paper on arXiv: Karapetyan S, Zeileis A, Henriksen A, Hapfelmeier A (2023).
+  "Tree Models for Assessing Covariate-Dependent Method Agreement."
+  arXiv 2306.04456, _arXiv.org E-Print Archive_.
+  [doi:10.48550/arXiv.2306.04456](https://doi.org/10.48550/arXiv.2306.04456)
+
+
+# Version 0.1.0
+
+* Internal first development version of `coat`, a new method and R package
+  for tree-based modeling of conditional method agreement. This leverages
+  the `ctree()` and `mob()` functions from R package
+  [partykit](https://CRAN.R-project.org/package=partykit) for the tree-based
+  modeling in combination with the well-established Bland-Altman analysis for
+  method agreement.

--- a/R/coat.R
+++ b/R/coat.R
@@ -36,6 +36,10 @@
 #' \code{y1 + y2 ~ x1 + ... + means(y1, y2)} or via
 #' \code{y1 + y2 ~ x1 + ... + I((y1 + y2)/2)}.
 #'
+#' @references Karapetyan S, Zeileis A, Henriksen A, Hapfelmeier A (2023).
+#' \dQuote{Tree Models for Assessing Covariate-Dependent Method Agreement.}
+#' arXiv 2306.04456, \emph{arXiv.org E-Print Archive}.
+#' \doi{10.48550/arXiv.2306.04456}
 #'
 #' @examples
 #' \dontshow{ if(!requireNamespace("MethComp")) {

--- a/R/coat.R
+++ b/R/coat.R
@@ -22,6 +22,21 @@
 #' agreement defaults to 20. Users may choose to modify this value as needed. See
 #' \code{\link[partykit]{ctree_control}} and \code{\link[partykit]{mob_control}} for details.
 #'
+#' In addition to the standard specification of the two response measurements in the
+#' formula via \code{y1 + y2 ~ ...}, it is also possible to use \code{y1 - y2 ~ ...}.
+#' The latter may be more intuitive for users that think of it as a model for the
+#' difference of two measurements. Finally \code{cbind(y1, y2) ~ ...} also works.
+#' Internally, all of these are processed in the same way, namely as a bivariate
+#' dependent variable that can then be modeled and plotted appropriately.
+#'
+#' To add the means of the measurement pair as a potential splitting variable,
+#' there are also different equivalent strategies. The standard specification would
+#' be via the \code{means} argument: \code{y1 + y2 ~ x1 + ..., means = TRUE}.
+#' Alternatively, the user can also extend the formula argument via
+#' \code{y1 + y2 ~ x1 + ... + means(y1, y2)} or via
+#' \code{y1 + y2 ~ x1 + ... + I((y1 + y2)/2)}.
+#'
+#'
 #' @examples
 #' \dontshow{ if(!requireNamespace("MethComp")) {
 #'   if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
@@ -67,6 +82,12 @@ coat <- function(formula, data, subset, na.action, weights, means = FALSE, type 
     formula <- update(formula, . ~ . + `_means_`)
     formula[[3L]][[3L]] <- formula[[2]]
     formula[[3L]][[3L]][[1L]] <- as.name("means")
+    m$formula <- formula
+  }
+  
+  ## if measurements are specified as `y1 - y2`, switch to `y1 + y2` internally
+  if(formula[[2L]][[1L]] == as.name("-")) {
+    formula[[2L]][[1L]] <- as.name("+")
     m$formula <- formula
   }
 

--- a/R/coat.R
+++ b/R/coat.R
@@ -33,8 +33,7 @@
 #' there are also different equivalent strategies. The standard specification would
 #' be via the \code{means} argument: \code{y1 + y2 ~ x1 + ..., means = TRUE}.
 #' Alternatively, the user can also extend the formula argument via
-#' \code{y1 + y2 ~ x1 + ... + means(y1, y2)} or via
-#' \code{y1 + y2 ~ x1 + ... + I((y1 + y2)/2)}.
+#' \code{y1 + y2 ~ x1 + ... + means(y1, y2)}.
 #'
 #' @references Karapetyan S, Zeileis A, Henriksen A, Hapfelmeier A (2023).
 #' \dQuote{Tree Models for Assessing Covariate-Dependent Method Agreement.}

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,14 @@
+bibentry(bibtype = "TechReport",
+         title = "Tree Models for Assessing Covariate-Dependent Method Agreement",
+         author = c(person(given = "Siranush", family = "Karapetyan", email = "Siranush.Karapetyan@mri.tum.de"),
+                    person(given = "Achim", family = "Zeileis", email = "Achim.Zeileis@R-project.org"),
+                    person(given = "André", family = "Henriksen", email = "Andre.Henriksen@uit.no"),
+                    person(given = "Alexander", family = "Hapfelmeier", email = "Alexander.Hapfelmeier@mri.tum.de")),
+         year = "2023",
+         institution = "arXiv.org E-Print Archive",
+         type = "arXiv",
+         number = "2306.04456",
+         month = "June",
+         doi = "10.48550/arXiv.2306.04456",
+         header = "To cite coat in publications use:"
+)

--- a/man/coat.Rd
+++ b/man/coat.Rd
@@ -85,3 +85,9 @@ plot(tr1)
 print(tr2)
 plot(tr2)
 }
+\references{
+Karapetyan S, Zeileis A, Henriksen A, Hapfelmeier A (2023).
+\dQuote{Tree Models for Assessing Covariate-Dependent Method Agreement.}
+arXiv 2306.04456, \emph{arXiv.org E-Print Archive}.
+\doi{10.48550/arXiv.2306.04456}
+}

--- a/man/coat.Rd
+++ b/man/coat.Rd
@@ -60,8 +60,7 @@ To add the means of the measurement pair as a potential splitting variable,
 there are also different equivalent strategies. The standard specification would
 be via the \code{means} argument: \code{y1 + y2 ~ x1 + ..., means = TRUE}.
 Alternatively, the user can also extend the formula argument via
-\code{y1 + y2 ~ x1 + ... + means(y1, y2)} or via
-\code{y1 + y2 ~ x1 + ... + I((y1 + y2)/2)}.
+\code{y1 + y2 ~ x1 + ... + means(y1, y2)}.
 }
 \examples{
 \dontshow{ if(!requireNamespace("MethComp")) {

--- a/man/coat.Rd
+++ b/man/coat.Rd
@@ -48,6 +48,20 @@ partitioning (MOB).
 The minimum number of observations required to model conditional
 agreement defaults to 20. Users may choose to modify this value as needed. See
 \code{\link[partykit]{ctree_control}} and \code{\link[partykit]{mob_control}} for details.
+
+In addition to the standard specification of the two response measurements in the
+formula via \code{y1 + y2 ~ ...}, it is also possible to use \code{y1 - y2 ~ ...}.
+The latter may be more intuitive for users that think of it as a model for the
+difference of two measurements. Finally \code{cbind(y1, y2) ~ ...} also works.
+Internally, all of these are processed in the same way, namely as a bivariate
+dependent variable that can then be modeled and plotted appropriately.
+
+To add the means of the measurement pair as a potential splitting variable,
+there are also different equivalent strategies. The standard specification would
+be via the \code{means} argument: \code{y1 + y2 ~ x1 + ..., means = TRUE}.
+Alternatively, the user can also extend the formula argument via
+\code{y1 + y2 ~ x1 + ... + means(y1, y2)} or via
+\code{y1 + y2 ~ x1 + ... + I((y1 + y2)/2)}.
 }
 \examples{
 \dontshow{ if(!requireNamespace("MethComp")) {


### PR DESCRIPTION
I've enabled the specification of the response by `y1 - y2 ~ ...` (see also https://github.com/Hapfelmeier/coat/issues/13) and enhanced the documentation of the formula processing.