### PR TITLE
Hyperparameter handling

### DIFF
--- a/R/coat.R
+++ b/R/coat.R
@@ -15,12 +15,26 @@
 #' @param means logical. Should the intra-individual mean values of measurements
 #' be included as potential split variable?
 #' @param type character string specifying the type of tree to be fit. Either \code{"ctree"} (default) or \code{"mob"}.
+#' @param minsize,minbucket integer. The minimum number of observations in a subgroup.
+#'   Only one of the two arguments should be used (see also below).
+#' @param minsplit integer. The minimum number of observations to consider splitting.
+#'   Must be at least twice the minimal subgroup size (\code{minsplit} or \code{minbucket}).
 #' @param ... further control arguments, either passed to \code{\link[partykit]{ctree_control}}
 #' or \code{\link[partykit]{mob_control}}, respectively.
 #'
-#' @details The minimum number of observations required to model conditional
-#' agreement defaults to 20. Users may choose to modify this value as needed. See
-#' \code{\link[partykit]{ctree_control}} and \code{\link[partykit]{mob_control}} for details.
+#' @details The minimum number of observations in a subgroup defaults to 10,
+#' so that the mean and variance of the measurement differences can be estimated
+#' reasonably for the Bland-Altman analysis. The default can be changed with
+#' with the argument \code{minsize} or, equivalently, \code{minbucket}.
+#' (The different names stem from slightly different conventions in the underlying
+#' tree functions.) Consequently, the minimum number of observations to consider
+#' splitting defaults to 25. At the very least it must be twice the minimum number
+#' of observations per subgroup (which would allow only one possible split, though).
+#' Users are encouraged to consider whether for their application it is sensible
+#' to increase or decrease these defaults. Finally, further control parameters
+#' can be specified through the \code{...} argument, see
+#' \code{\link[partykit]{ctree_control}} and \code{\link[partykit]{mob_control}},
+#' respectively, for details.
 #'
 #' In addition to the standard specification of the two response measurements in the
 #' formula via \code{y1 + y2 ~ ...}, it is also possible to use \code{y1 - y2 ~ ...}.
@@ -68,7 +82,8 @@
 #' @importFrom partykit ctree_control mob_control
 #'
 #' @export
-coat <- function(formula, data, subset, na.action, weights, means = FALSE, type = c("ctree", "mob"), ...)
+coat <- function(formula, data, subset, na.action, weights, means = FALSE, type = c("ctree", "mob"),
+  minsize = 10L, minbucket = minsize, minsplit = 25L, ...)
 {
   ## type of tree
   type <- match.arg(tolower(type), c("ctree", "mob"))
@@ -98,21 +113,36 @@ coat <- function(formula, data, subset, na.action, weights, means = FALSE, type 
   m$means <- NULL
   m$type <- NULL
 
+  ## process hyperparameters
+  if(!missing(minsize) && !missing(minbucket)) {
+    warning("the minimal subgroup size should either be specified by 'minsize' or 'minbucket' but not both, using 'minsize'")
+    minbucket <- minsize
+  }
+  minsize <- minbucket
+  if(minsplit < 2L * minsize) {
+    warning("the minimal sample size to consider splitting ('minsplit') must be at least twice the minimal subgroup size ('minsize'), increased accordingly")
+    minsplit <- 2L * minsize
+  }
+
   ## add fit/trafo function
   if(type == "mob") {
     m[[1L]] <- as.call(quote(partykit::mob))
     m$fit <- bafit
-    m$control <- partykit::mob_control(...)
+    m$control <- partykit::mob_control(minsize = minsize, minsplit = minsplit, ...)
     m$control$ytype <- "matrix"
-    if(is.null(m$control$minsize) && is.null(m$control$minbucket)) m$control$minsize <- 20L
   } else {
     m[[1L]] <- as.call(quote(partykit::ctree))
     m$ytrafo <- batrafo
-    m$control <- partykit::ctree_control(...)
+    m$control <- partykit::ctree_control(minbucket = minsize, minsplit = minsplit, ...)
   }
 
   ## fit tree
   rval <- eval(m, parent.frame())
+  
+  ## informative warning if sample size is too small for splitting
+  if(is.null(rval$node$split) && rval$node$info$nobs < minsplit) {
+    message("the number of observations is less than the minimal sample size to consider splitting ('minsplit'), please consider whether 'minsplit'/'minsize' should be adjusted")
+  }
   
   ## unify output
   rval$info$call <- cl

--- a/R/coat.R
+++ b/R/coat.R
@@ -16,9 +16,11 @@
 #' be included as potential split variable?
 #' @param type character string specifying the type of tree to be fit. Either \code{"ctree"} (default) or \code{"mob"}.
 #' @param minsize,minbucket integer. The minimum number of observations in a subgroup.
-#'   Only one of the two arguments should be used (see also below).
+#' Only one of the two arguments should be used (see also below).
 #' @param minsplit integer. The minimum number of observations to consider splitting.
-#'   Must be at least twice the minimal subgroup size (\code{minsplit} or \code{minbucket}).
+#' Must be at least twice the minimal subgroup size (\code{minsplit} or \code{minbucket}).
+#' If set to \code{NULL} (the default) it is set to be at least 2.5 times the minimal
+#' subgroup size.
 #' @param ... further control arguments, either passed to \code{\link[partykit]{ctree_control}}
 #' or \code{\link[partykit]{mob_control}}, respectively.
 #'
@@ -28,8 +30,9 @@
 #' with the argument \code{minsize} or, equivalently, \code{minbucket}.
 #' (The different names stem from slightly different conventions in the underlying
 #' tree functions.) Consequently, the minimum number of observations to consider
-#' splitting defaults to 25. At the very least it must be twice the minimum number
+#' splitting (\code{minsplit}) must be, at the very least, twice the minimum number
 #' of observations per subgroup (which would allow only one possible split, though).
+#' By default, \code{minsplit} is 2.5 times \code{minsize}.
 #' Users are encouraged to consider whether for their application it is sensible
 #' to increase or decrease these defaults. Finally, further control parameters
 #' can be specified through the \code{...} argument, see
@@ -83,7 +86,7 @@
 #'
 #' @export
 coat <- function(formula, data, subset, na.action, weights, means = FALSE, type = c("ctree", "mob"),
-  minsize = 10L, minbucket = minsize, minsplit = 25L, ...)
+  minsize = 10L, minbucket = minsize, minsplit = NULL, ...)
 {
   ## type of tree
   type <- match.arg(tolower(type), c("ctree", "mob"))
@@ -119,6 +122,7 @@ coat <- function(formula, data, subset, na.action, weights, means = FALSE, type 
     minbucket <- minsize
   }
   minsize <- minbucket
+  if(is.null(minsplit)) minsplit <- ceiling(2.5 * minsize)
   if(minsplit < 2L * minsize) {
     warning("the minimal sample size to consider splitting ('minsplit') must be at least twice the minimal subgroup size ('minsize'), increased accordingly")
     minsplit <- 2L * minsize

--- a/R/coat.R
+++ b/R/coat.R
@@ -143,9 +143,9 @@ coat <- function(formula, data, subset, na.action, weights, means = FALSE, type 
   ## fit tree
   rval <- eval(m, parent.frame())
   
-  ## informative warning if sample size is too small for splitting
-  if(is.null(rval$node$split) && rval$node$info$nobs < minsplit) {
-    message("the number of observations is less than the minimal sample size to consider splitting ('minsplit'), please consider whether 'minsplit'/'minsize' should be adjusted")
+  ## informative warning if tree considered splitting at all
+  if(is.null(rval$node$split) && (is.null(rval$node$info) || is.null(rval$node$info$test))) {
+    message("Info: The tree has no splits due to the hyperparameters ('minsize', 'minsplit', ...), no test were carried out, possibly consider adjusting the hyperparameters.")
   }
   
   ## unify output

--- a/man/coat.Rd
+++ b/man/coat.Rd
@@ -12,6 +12,9 @@ coat(
   weights,
   means = FALSE,
   type = c("ctree", "mob"),
+  minsize = 10L,
+  minbucket = minsize,
+  minsplit = 25L,
   ...
 )
 }
@@ -30,6 +33,12 @@ be included as potential split variable?}
 
 \item{type}{character string specifying the type of tree to be fit. Either \code{"ctree"} (default) or \code{"mob"}.}
 
+\item{minsize, minbucket}{integer. The minimum number of observations in a subgroup.
+Only one of the two arguments should be used (see also below).}
+
+\item{minsplit}{integer. The minimum number of observations to consider splitting.
+Must be at least twice the minimal subgroup size (\code{minsplit} or \code{minbucket}).}
+
 \item{...}{further control arguments, either passed to \code{\link[partykit]{ctree_control}}
 or \code{\link[partykit]{mob_control}}, respectively.}
 }
@@ -45,9 +54,19 @@ via conditional inference trees (CTree) or using model-based recursive
 partitioning (MOB).
 }
 \details{
-The minimum number of observations required to model conditional
-agreement defaults to 20. Users may choose to modify this value as needed. See
-\code{\link[partykit]{ctree_control}} and \code{\link[partykit]{mob_control}} for details.
+The minimum number of observations in a subgroup defaults to 10,
+so that the mean and variance of the measurement differences can be estimated
+reasonably for the Bland-Altman analysis. The default can be changed with
+with the argument \code{minsize} or, equivalently, \code{minbucket}.
+(The different names stem from slightly different conventions in the underlying
+tree functions.) Consequently, the minimum number of observations to consider
+splitting defaults to 25. At the very least it must be twice the minimum number
+of observations per subgroup (which would allow only one possible split, though).
+Users are encouraged to consider whether for their application it is sensible
+to increase or decrease these defaults. Finally, further control parameters
+can be specified through the \code{...} argument, see
+\code{\link[partykit]{ctree_control}} and \code{\link[partykit]{mob_control}},
+respectively, for details.
 
 In addition to the standard specification of the two response measurements in the
 formula via \code{y1 + y2 ~ ...}, it is also possible to use \code{y1 - y2 ~ ...}.

--- a/man/coat.Rd
+++ b/man/coat.Rd
@@ -14,7 +14,7 @@ coat(
   type = c("ctree", "mob"),
   minsize = 10L,
   minbucket = minsize,
-  minsplit = 25L,
+  minsplit = NULL,
   ...
 )
 }
@@ -37,7 +37,9 @@ be included as potential split variable?}
 Only one of the two arguments should be used (see also below).}
 
 \item{minsplit}{integer. The minimum number of observations to consider splitting.
-Must be at least twice the minimal subgroup size (\code{minsplit} or \code{minbucket}).}
+Must be at least twice the minimal subgroup size (\code{minsplit} or \code{minbucket}).
+If set to \code{NULL} (the default) it is set to be at least 2.5 times the minimal
+subgroup size.}
 
 \item{...}{further control arguments, either passed to \code{\link[partykit]{ctree_control}}
 or \code{\link[partykit]{mob_control}}, respectively.}
@@ -60,8 +62,9 @@ reasonably for the Bland-Altman analysis. The default can be changed with
 with the argument \code{minsize} or, equivalently, \code{minbucket}.
 (The different names stem from slightly different conventions in the underlying
 tree functions.) Consequently, the minimum number of observations to consider
-splitting defaults to 25. At the very least it must be twice the minimum number
+splitting (\code{minsplit}) must be, at the very least, twice the minimum number
 of observations per subgroup (which would allow only one possible split, though).
+By default, \code{minsplit} is 2.5 times \code{minsize}.
 Users are encouraged to consider whether for their application it is sensible
 to increase or decrease these defaults. Finally, further control parameters
 can be specified through the \code{...} argument, see


### PR DESCRIPTION
As discussed today I have adjusted the hyperparameter handling by adding the following arguments to `coat()`:

- `minsize = 10`
- `minbucket = minsize`
- `minsplit = NULL` which is equivalent to `ceiling (2.5 * minsize)`

Thus, I enable setting of the minimum subgroup size in `rpart` style (`minbucket`) or via the more intelligible `minsize` that `mob()` advertises. And `minsplit` is set depending on the other parameters so that I don't have to always change both.

In addition an info  `message()` is issued if the tree has no splits without even considering potential splits. This might be due to `minsplit`, `minsize`, `maxdepth`, etc.